### PR TITLE
fix: scroll_to_bottom scrolls the y offset not the x offset

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -80,6 +80,6 @@ impl ScrollViewState {
         let bottom = self
             .size
             .map_or(u16::MAX, |size| size.height.saturating_sub(1));
-        self.offset.x = bottom;
+        self.offset.y = bottom;
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/joshka/tui-scrollview/issues/23
